### PR TITLE
Fix/marbles in kennel and play

### DIFF
--- a/server/py/dog.py
+++ b/server/py/dog.py
@@ -167,7 +167,7 @@ class Dog(Game):
             pass  # TODO: implement for other tests
 
     def _get_marbles_in_kennel_and_in_play(self, player: PlayerState) -> tuple[list[Marble], list[Marble]]:
-        kennel_positions = KennelNumbers[player.colour]["kennel"]
+        kennel_positions = KennelNumbers[player.colour]
         marbles_in_play, marbles_in_kennel = [], []
         for marble in player.list_marble:
             if marble.pos not in kennel_positions:
@@ -178,7 +178,7 @@ class Dog(Game):
 
     def _if_all_marbles_in_kennel(self, player: PlayerState, marbles_in_kennel: list[Marble]) -> list[Action]:
         """Lists all actions that are possible if all marbles of a player are in the kennel."""
-        start_position = StartNumbers[player.colour]["start"]
+        start_position = StartNumbers[player.colour]
         card_ranks = [card.rank for card in player.list_card]
         if not any(item in card_ranks for item in ["JKR", "A", "K"]):
             return []


### PR DESCRIPTION
# PR Description
### What is the content of this PR? Which functionality did you add?
This PR contains the following changes:
* separated `KennelAndStartNumbers` Enum object into two separate `KennelNumbers` & `StartNumbers` objects
* changed type of `Marble.pos` from `str` to `int`, since all the other position attributes in the game are `int` as well
* removed custom `in_kennel` attribute from `Marble` object and stopped retrieving the marbles in play and in kennel from the `in_kennel` attribute and instead get them from the kennel positions in `KennelNumbers`.

### Which methods or objects did you modify?
* KennelAndStartNumbers
* Marble
* _get_marbles_in_kennel_and_in_play
* _if_all_marbles_in_kennel

### Which tests have passed?

Tests: 6/57 valid
Mark:  10/121 points

Please mark the tests that have passed.

- [x] Test 1
- [ ] Test 2
- [x] Test 3
- [x] Test 4
- [x] Test 5
- [ ] Test 6
- [ ] Test 7
- [ ] Test 8
- [ ] Test 9
- [ ] Test 10
- [ ] Test 11
- [ ] Test 12
- [ ] Test 13
- [ ] Test 14
- [ ] Test 15
- [ ] Test 16
- [ ] Test 17
- [ ] Test 18
- [ ] Test 19
- [ ] Test 20
- [ ] Test 21
- [ ] Test 22
- [ ] Test 23
- [ ] Test 24
- [ ] Test 25
- [ ] Test 26
- [ ] Test 27
- [ ] Test 28
- [ ] Test 29
- [ ] Test 30
- [ ] Test 31
- [ ] Test 32
- [ ] Test 33
- [ ] Test 34
- [ ] Test 35
- [ ] Test 36
- [ ] Test 37
- [ ] Test 38
- [ ] Test 39
- [x] Test 40
- [ ] Test 41
- [ ] Test 42
- [ ] Test 43
- [ ] Test 44
- [ ] Test 45
- [x] Test 46
- [ ] Test 47
- [ ] Test 48
- [ ] Test 49
- [ ] Test 50
- [ ] Test 51
- [ ] Test 52
- [ ] Test 53
- [ ] Test 54
- [ ] Test 100
- [ ] Test 101
- [ ] Test 102
